### PR TITLE
Fix bug endline caracter solv2

### DIFF
--- a/config/script/payara/convert_endline_character.sh
+++ b/config/script/payara/convert_endline_character.sh
@@ -1,0 +1,1 @@
+for i in *; do sed -i -e 's/\r$//' $i; done;

--- a/makefile
+++ b/makefile
@@ -7,6 +7,8 @@ init: docker-compose.yml .env;
 	echo -e "\nAdicionando scripts...\n"; \
 	cp ./config/script/payara/*.sh ${PAYARA_LOCAL_DIR}/bin/; \
 	sudo chmod -R 777 ${PAYARA_LOCAL_DIR}; \
+	echo -e "\nConvertendo caracteres de fim de linha...\n"; \
+	docker exec -it hostel-app-gcva_hostel-app-server_1 bash /opt/payara41/bin/convert_endline_character.sh; \
 	echo -e "\nPronto!\n"; \
 
 #Configurar jdbc connector e connection pool


### PR DESCRIPTION
O windows e o linux usam codificações diferentes para representar o 'fim de linha', e isso gera problema quando você tenta executar scripts do windows no linux, esse pull request visa corrigir esse problema adicionando o script 'convert_endline_character.sh' e padronizando o caracter usado para 'fim de linha'